### PR TITLE
Aleks and Hao Aseembly Beta-test

### DIFF
--- a/book/opmanual_duckiebot/atoms_17_setup_duckiebot_DB17-jwd/1_0_21_assembling_duckiebot_DB18.md
+++ b/book/opmanual_duckiebot/atoms_17_setup_duckiebot_DB17-jwd/1_0_21_assembling_duckiebot_DB18.md
@@ -1,7 +1,7 @@
 # Assembling the Duckiebot (`DB18`)  {#assembling-duckiebot-db18 status=ready}
 
 Point of contact: Gianmarco Bernasconi, Jacopo Tani
-Put one motor between the holders as 
+
 Once you have received the parts, it is time to assemble them in a Duckiebot. Here, we provide the assembly instructions for the configuration `DB18`.
 
 <div class='requirements' markdown="1">

--- a/book/opmanual_duckiebot/atoms_17_setup_duckiebot_DB17-jwd/1_0_21_assembling_duckiebot_DB18.md
+++ b/book/opmanual_duckiebot/atoms_17_setup_duckiebot_DB17-jwd/1_0_21_assembling_duckiebot_DB18.md
@@ -1,7 +1,7 @@
 # Assembling the Duckiebot (`DB18`)  {#assembling-duckiebot-db18 status=ready}
 
 Point of contact: Gianmarco Bernasconi, Jacopo Tani
-
+Put one motor between the holders as 
 Once you have received the parts, it is time to assemble them in a Duckiebot. Here, we provide the assembly instructions for the configuration `DB18`.
 
 <div class='requirements' markdown="1">
@@ -109,6 +109,8 @@ Put one motor between the holders as shown in [](#fig:howto-mount-motors-2).
 </div>
 
 Note: Orient the motors so that their wires are inwards (i.e., towards the center of the plate).
+
+Note: Use your screwdriver.
 
 
 ### Step 3
@@ -303,6 +305,8 @@ From the Duckiebot kit take the following components:
 - Camera cable (1x)
 - Micro SD card (1x)
 
+Note: You might have two heat sinks, make sure you use the one in the picture (should be the bigger one).
+
 [](#fig:howto-mount-rpi-parts) shows the components needed to complete this part of the tutorial.
 
 <div figure-id="fig:howto-mount-rpi-parts" figure-caption="The heat sinks and the Raspberry Pi 3B+.">
@@ -363,7 +367,7 @@ From the previously prepared pieces take the following components:
 
 From the Duckiebot kit take the following components:
 
-- Duckietown Hut (1x)
+- Duckiebot Hut (1x)
 - M2.5x12 nylon spacers (4x)
 - M2.5 nylon nuts (4x)
 - USB to micro USB cables (2x)
@@ -379,7 +383,7 @@ Note: It is cleaner if you do not separate each cable, but leave them in two set
 
 ### Step 1
 
-Place the spacers on the bottom part of the Duckietown hut, as in [](#fig:howto-assemble-hut-1)
+Place the spacers on the bottom part of the Duckiebot hut, as in [](#fig:howto-assemble-hut-1)
 
 <div figure-id="fig:howto-assemble-hut-1" figure-caption="Position of the nylon spacers.">
      <img src="howto_assemble_hut_1.png" style='width: 25em'/>
@@ -387,11 +391,11 @@ Place the spacers on the bottom part of the Duckietown hut, as in [](#fig:howto-
 
 ### Step 2
 
-From the top of the Duckietown Hut, secure using the M2.5 nylon nuts.
+From the top of the Duckiebot Hut, secure using the M2.5 nylon nuts.
 
 ### Step 3
 
-Place the Raspberry Pi as in [](#fig:howto-assemble-hut-2), passing the camera cable through the slit in the Duckietown Hut. Then plug in the Duckietown Hut, by making sure that the Raspberry Pi pins fit into the Hut connector. Finally, plug in the USB cables in the two micro USB ports.
+Place the Raspberry Pi as in [](#fig:howto-assemble-hut-2), passing the camera cable through the slit in the Duckiebot Hut. Then plug in the Duckiebot Hut, by making sure that the Raspberry Pi pins fit into the Hut connector. 
 
 <div figure-id="fig:howto-assemble-hut-2" figure-caption="Position of the nylon spacers.">
      <img src="howto_assemble_hut_2.jpg" style='width: 25em'/>
@@ -407,7 +411,7 @@ Take one of the two sets of F/F jumper wires, and attach it to the Duckietown Hu
 
 ### Step 5
 
-Finally, attach the two USB cable to the power plugs, as in [](#fig:assembly-db18-power-cables). Note that the color of the USB cables might vary, so don't worry if yours are not exactly as those shown in the picture below.
+Finally, attach the two USB cable to the power plugs, as in [](#fig:assembly-db18-power-cables). Note that the color of the USB cables might vary, so don't worry if yours are not exactly as those shown in the picture below. The two USB cables could also be uncomfortably short. If your powerbank/battery comes with longer cables you might want to use them instead.
 
 <div figure-id="fig:assembly-db18-power-cables" figure-caption="Plugging in the power cables.">
      <img src="assembly-db18-power-cables.jpg" style='width: 25em'/>
@@ -471,6 +475,8 @@ From the Duckiebot kit take the following components:
 
 - M2.5x10 Nylon screws (4x)
 - M2.5x4 Nylon spacers (4x)
+
+Note: By this moment you probably have both M2.5 and M3 Nylon screws. Make sure you use the M2.5 ones. Do not force the M3 screws.
 
 [](#fig:howto-assemble-rpi-top-parts) shows the components needed to complete this part of the tutorial.
 


### PR DESCRIPTION
Some edits suggested after some TA beta-testing today:

- A small note on when attaching the motors
- A small note on which heat sink to use (I, of course, first put the wrong one)
- "Duckietown Hut" was used in the Raspberry Pi and Hut section. The actual board says "Duckiebot Hut", so I change it to that. 
- Removed "Finally, plug in the USB cables in the two micro USB ports." from Step 3 of the same section as there is a separate step for that: Step 5
- Added a remark that one can use the longer USB cables that came with the powerbank
- In "Raspberry Pi and top plate" added a note on not taking the M3 Nylon screws by mistake (I did that, and fun fact, after you screw one of these in, you can't get it out...)
- Step 2 of Chassis assembly: haven't edited it because I am not sure what's actually correct. When talking about left and right motor, is that when the bottom part is upright (motors under) or upside-down (motors above, as in fig 7.98)?
- Front bumper assembly: haven't changed anything but we noticed that if looking at the pictures it seems we have to partially disassemble the bot that we just assembled so that we can pass the electric F/F cables through the top chassis. It is possible without disassembling it, but the photo might be a bit confusing