### PR TITLE
Section on "Securing your Duckiebot" updated

### DIFF
--- a/book/opmanual_duckiebot/atoms_17_operation_manual_duckiebot/1_0_20_duckiebot_initialization-db18.md
+++ b/book/opmanual_duckiebot/atoms_17_operation_manual_duckiebot/1_0_20_duckiebot_initialization-db18.md
@@ -125,7 +125,7 @@ This configuration was added by the `init_sd_card` command.
 
 By default your Duckiebot uses an SSH key that is the same for all Duckiebots. That means that anyone can access your Duckiebot. If you want to prevent this (in particular if you have your university internet credentials on the Duckiebot), then remove this key by running
 
-    laptop $ ssh ![hostname] rm /home/![linux-username]/.ssh/authorized_keys
+    laptop $ ssh ![hostname] rm .ssh/authorized_keys
 
 The ![linux-username] is `duckie` by default unless you changed it while initializing your SD Card. 
 

--- a/book/opmanual_duckiebot/atoms_17_operation_manual_duckiebot/1_0_20_duckiebot_initialization-db18.md
+++ b/book/opmanual_duckiebot/atoms_17_operation_manual_duckiebot/1_0_20_duckiebot_initialization-db18.md
@@ -125,7 +125,9 @@ This configuration was added by the `init_sd_card` command.
 
 By default your Duckiebot uses an SSH key that is the same for all Duckiebots. That means that anyone can access your Duckiebot. If you want to prevent this (in particular if you have your university internet credentials on the Duckiebot), then remove this key by running
 
-    laptop $ ssh ![hostname] rm ~/.ssh/authorized_keys
+    laptop $ ssh ![hostname] rm /home/![linux-username]/.ssh/authorized_keys
+
+The ![linux-username] is `duckie` by default unless you changed it while initializing your SD Card. 
 
 After this you will be prompted for your password every time you connect to your Duckiebot. If the password which you set in the SD card initialization process was not strong enough, or you kept the default password, we recommend you change it now.
  


### PR DESCRIPTION
The `~` symbol resolves to the home directory of the user who is logged in. Since the command is running on our laptops, it would resolve to our user's home directory and not the duckiebot.