### PR TITLE
Missing volume binding

### DIFF
--- a/book/opmanual_duckiebot/atoms_17_operation_manual_duckiebot/2_2_3_wheel_calibration.md
+++ b/book/opmanual_duckiebot/atoms_17_operation_manual_duckiebot/2_2_3_wheel_calibration.md
@@ -39,7 +39,7 @@ If you just finished the [camera calibration step](#camera-calib) then you have 
 Get a base container running on your robot if you don't have one already:
 
 
-    laptop $ docker -H ![hostname].local run -it --net host --privileged  duckietown/rpi-duckiebot-base:master18
+    laptop $ docker -H ![hostname].local run -it --net host --privileged -v /data:/data duckietown/rpi-duckiebot-base:master18
 
 
 


### PR DESCRIPTION
The command needs to have `-v /data:/data` 
It's absence causes `make hw-test-kinematics` to not find the calibration files in /data