### PR TITLE
Update 2_0_5_make_it_move.md

### DIFF
--- a/book/opmanual_duckiebot/atoms_17_operation_manual_duckiebot/2_0_5_make_it_move.md
+++ b/book/opmanual_duckiebot/atoms_17_operation_manual_duckiebot/2_0_5_make_it_move.md
@@ -29,7 +29,7 @@ both for the laptop and for the Duckiebot. The procedure is documented in [](+so
     
 Use the following command to run the container that contains `roscore`:
 
-    laptop $ docker -H ![hostname].local run -dit --privileged --name roscore --net host --restart unless-stopped duckietown/rpi-ros-kinetic-roscore:master18
+    laptop $ docker -H ![hostname].local run -dit --privileged --name roscore --net host -v /data:/data --restart unless-stopped duckietown/rpi-ros-kinetic-roscore:master18
     
 If this is the first time you run this, it might take some time to download the container.
 


### PR DESCRIPTION
The `/data` folder mounting was not in the Docker run for starting `rpi-ros-kinetic-roscore` which might cause issues with the wheel calibration later.