### PR TITLE
Migrate docs to lighter picamera

### DIFF
--- a/book/opmanual_duckiebot/atoms_17_operation_manual_duckiebot/2_0_6_camera_data.md
+++ b/book/opmanual_duckiebot/atoms_17_operation_manual_duckiebot/2_0_6_camera_data.md
@@ -19,10 +19,9 @@ It might be useful to do a quick camera hardware check as documented in [](#howt
 These commands assume that you have completed the steps in [](#docker-setup),
 and in particular that you set `DOCKER_HOST` correctly and can use `docker ps` successfully.
 
-Start the container `rpi-docker-python-picamera`. It reads the camera
-image and writes it to `/data`.
+Start the container `rpi-python-picamera`. It reads the camera image and writes it to `/data`.
 
-    laptop $ docker -H ![hostname].local run -d --name picam --device /dev/vchiq -v /data:/data duckietown/rpi-docker-python-picamera:master18
+    laptop $ docker -H ![hostname].local run -d --name picam --device /dev/vchiq -v /data:/data duckietown/rpi-python-picamera:master18
 
 Then point your browser to the address
 

--- a/book/opmanual_duckiebot/atoms_18_setup_troubleshooting/50_camera_trouble.md
+++ b/book/opmanual_duckiebot/atoms_18_setup_troubleshooting/50_camera_trouble.md
@@ -7,7 +7,7 @@ Maintainer: Russell Buchanan
 ### Resolution: make sure the picam container is running
 You can run with:
 
-    laptop $ docker -H ![hostname].local run -d --name picam --device /dev/vchiq -v /data:/data duckietown/rpi-docker-python-picamera:master18
+    laptop $ docker -H ![hostname].local run -d --name picam --device /dev/vchiq -v /data:/data duckietown/rpi-python-picamera:master18
 
 ### Resolution: make sure dt18_01_health_stats_rpi-simple-server_1 container is running.
 If it's not running something went wrong with your initialization. Try:


### PR DESCRIPTION
As described in duckietown/rpi-docker-python-picamera#1, [`duckietown/rpi-python-picamera`](https://github.com/duckietown/rpi-python-picamera):
* Is 50% lighter picamera than [`duckietown/rpi-docker-python-picamera`](https://github.com/duckietown/rpi-docker-python-picamera)
* Has a more logical naming convention (why do we need `-docker`?)
* Conforms to [DOTADIW](https://en.wikipedia.org/wiki/Unix_philosophy#Do_One_Thing_and_Do_It_Well) (i.e. now that we preload [`duckietown/rpi-python-picamera`](https://github.com/duckietown/rpi-python-picamera), it should not be necessary to [start an HTTP server](https://github.com/duckietown/rpi-docker-python-picamera/blob/master18/start.sh#L4) from inside the picamera contianer)