### PR TITLE
added procedure for flashing the microcontroller on the book 

### DIFF
--- a/book/opmanual_duckiebot/atoms_17_operation_manual_duckiebot/1_0_20_duckiebot_initialization-db18.md
+++ b/book/opmanual_duckiebot/atoms_17_operation_manual_duckiebot/1_0_20_duckiebot_initialization-db18.md
@@ -102,7 +102,7 @@ PING ![hostname].local (![X.X.X.X]): 56 data bytes
 ```
 ### Troubleshooting
 
-Symptom: The LEDs light up in a variety of colors when i plug in the battery.
+Symptom: The LEDs light up in a variety of colors when the battery is plugged in.
 
 Resolution: The LEDs of the Duckiebot should light up in white as soon as you power the Duckiebot. If the LEDs turn on and shine in any different color than white, probably the code on the microcontroller is corrupted. You can reflash it using the procedure in [](#setup-troubleshooting-boot).
 

--- a/book/opmanual_duckiebot/atoms_17_operation_manual_duckiebot/1_0_20_duckiebot_initialization-db18.md
+++ b/book/opmanual_duckiebot/atoms_17_operation_manual_duckiebot/1_0_20_duckiebot_initialization-db18.md
@@ -1,6 +1,6 @@
 # Duckiebot Initialization {#setup-duckiebot status=ready}
 
-This page is for the `DB18` configuration used in classes in 2018. For last year's instructions see [here](https://docs.duckietown.org/DT17/).
+This page is for the `DB18` configuration used in classes in 2019. For last year's instructions see [here](https://docs.duckietown.org/DT18/).
 
 <div class='requirements' markdown="1">
 
@@ -79,7 +79,7 @@ You should immediately see the **green** light next to where the SD card was ins
 
 If not, stop, as there is a problem with the SD card initialization (or possibly the PI, but this is unlikely).
 
-Warning: Allow the robot time to boot. On first boot it may take up to 20 mins. You will see the LED lights go off when the robot is ready to use. 
+Warning: Allow the robot time to boot. On first boot it may take up to 20 minutes until the Duckiebot is connected to the network. During this period the LEDs should be white. Consequently, the Duckiebot will automatically start to download the needed software. The RPi LEDs will alternatingly blink red and green while the Docker stacks are being loaded, and solid green (with the red off) when it is ready to use.
 
 Do not power the robot off (by holding the battery button) while this is in process.
 
@@ -100,7 +100,11 @@ PING ![hostname].local (![X.X.X.X]): 56 data bytes
 64 bytes from ![X.X.X.X]: icmp_seq=1 ttl=64 time=2.303 ms
 ![...]
 ```
+### Troubleshooting
 
+Symptom: The LEDs light up in a variety of colors when i plug in the battery.
+
+Resolution: The LEDs of the Duckiebot should light up in white as soon as you power the Duckiebot. If the LEDs turn on and shine in any different color than white, probably the code on the microcontroller is corrupted. You can reflash it using the procedure in [](#setup-troubleshooting-boot).
 
 
 ## SSH to the Duckiebot {#setup-duckiebot-ssh}

--- a/book/opmanual_duckiebot/atoms_17_operation_manual_duckiebot/1_0_20_duckiebot_initialization-db18.md
+++ b/book/opmanual_duckiebot/atoms_17_operation_manual_duckiebot/1_0_20_duckiebot_initialization-db18.md
@@ -75,11 +75,15 @@ Now insert the SD card into the Raspberry PI and push the button on the battery 
 
 Warning: Don't charge the battery while you are doing the initialization (or in general when the Duckiebot is turned on). The external power supply might not be able to provide sufficient current and the Raspberry Pi will reboot. Should that happen during the initialization procedure, you will likely have to burn the SD card again.
 
-You should immediately see the **green** light next to where the SD card was inserted start to blink with activity.
+You should immediately see the **green** LED of the Raspberry Pi next to where the SD card was inserted start to blink with activity.
 
-If not, stop, as there is a problem with the SD card initialization (or possibly the PI, but this is unlikely).
+If not, stop, as there is a problem with the SD card initialization (or possibly the Raspberry Pi, but this is unlikely).
 
-Warning: Allow the robot time to boot. On first boot it may take up to 20 minutes until the Duckiebot is connected to the network. During this period the LEDs should be white. Consequently, the Duckiebot will automatically start to download the needed software. The RPi LEDs will alternatingly blink red and green while the Docker stacks are being loaded, and solid green (with the red off) when it is ready to use.
+After some time, the **red** and the **green** LEDs of the Raspberry Pi will start to blink alternately. This means that the necessary Docker containers are being extracted. When the process is finished the **red** LED will be off and the **green** will be on.
+
+Warning: Allow the robot time to boot. Wait until only the green Raspberry Pi LED is on, while the red is off. This might take a lot of time.
+
+Warning: Allow the robot time to boot. Wait until only the green Raspberry Pi LED is on, while the red is off. This might take a lot of time.
 
 Do not power the robot off (by holding the battery button) while this is in process.
 

--- a/book/opmanual_duckiebot/atoms_18_setup_troubleshooting/10_boot_and_recovery.md
+++ b/book/opmanual_duckiebot/atoms_18_setup_troubleshooting/10_boot_and_recovery.md
@@ -30,11 +30,11 @@ Resolution: An older version of the SD card image had the docker container `cjim
     duckiebot $ sudo systemctl unmask wpa_supplicant
     duckiebot $ sudo systemctl restart networking.service
 
-## The LEDs light up in a variety of colors when i plug in the battery.
+## Flashing the microcontroller.
 
-Symptom: The LEDs light up in a variety of colors when i plug in the battery.
+Symptom: The LEDs light up in a variety of colors when the battery is plugged in.
 
-Resolution: The LEDs of the Duckiebot should light up in white as soon as you power the Duckiebot. If the LEDs turn on and shine in any different color than white, probably the code on the microcontroller is corrupted. You can reflash it using the following procedure:
+Resolution: The LEDs of the Duckiebot should light up in white as soon as you power the Duckiebot. If the LEDs turn on and shine in any different color than white, probably the code on the microcontroller (MC) is corrupted. You can reflash it using the following procedure:
 
 `ssh` into your robot and clone the Duckietown Software repository with:
 
@@ -67,7 +67,8 @@ if the output of `make fuses` is at the end like
 
     avrdude done.  Thank you.
 
-the connection to the MC works and the fuses could be written. The fuses are some low lowlevel settings, which just have to be set once for each microcontroller.  If this succeeded, jump the next step.
+the connection to the MC works and the fuses could be written. The fuses are some low lowlevel settings, which just have to be set once. If this succeeded, jump the next step.
+
 
 If there is the message "make: warning: Clock skew detected. Your build may be incomplete." or the make process is not stopping and many debugging messages are showed, try the following:
 Press <kbd>Ctrl</kbd>-<kbd>C</kbd> to stop the current command. Then run:
@@ -75,6 +76,7 @@ Press <kbd>Ctrl</kbd>-<kbd>C</kbd> to stop the current command. Then run:
     duckiebot $ find -exec touch \{\} \;
 
 This ensures that the modification time of all files is set to the current time. Make decides, which files have to be compiled by comparing the source file time with the executable file time. If the executable file time lies in the future regarding the current system time, not all modified files are compiled. This could happen when the clock of the Raspberry Pi is not set correctly and the file timestamps of, e.g., a github pull are used.
+
 
 Next up, remove all temporary files, so everything has to be compiled freshly by running:  
 
@@ -85,7 +87,6 @@ Compile the programm and download it to the MC by running:
     duckiebot $ make
 
 the output should look like:
-    ...
 
     Errors: none
     -------- end --------
@@ -122,7 +123,7 @@ the output should look like:
 
     avrdude done.  Thank you.
 
-With that, the MC should work. To change the MC programm, just edit the files, e.g with vim. With `&#36; make` you can compile and download the programm to the MC again.
+With that, the MC should work. To change the MC programm, just edit the files, e.g with vim. With `make` you can compile and download the programm to the MC again.
 
 In the end, make sure to delete the Software repository to free up the space again. This is done by running:
 

--- a/book/opmanual_duckiebot/atoms_18_setup_troubleshooting/10_boot_and_recovery.md
+++ b/book/opmanual_duckiebot/atoms_18_setup_troubleshooting/10_boot_and_recovery.md
@@ -30,11 +30,11 @@ Resolution: An older version of the SD card image had the docker container `cjim
     duckiebot $ sudo systemctl unmask wpa_supplicant
     duckiebot $ sudo systemctl restart networking.service
 
-## Flashing the microcontroller.
+## Flashing the microcontroller
 
 Symptom: The LEDs light up in a variety of colors when the battery is plugged in.
 
-Resolution: The LEDs of the Duckiebot should light up in white as soon as you power the Duckiebot. If the LEDs turn on and shine in any different color than white, probably the code on the microcontroller (MC) is corrupted. You can reflash it using the following procedure:
+Resolution: The LEDs of the Duckiebot should light up in white as soon as you power the Duckiebot. If the LEDs turn on and shine in any different color than white, probably the code on the microcontroller is corrupted. You can reflash it using the following procedure:
 
 `ssh` into your robot and clone the Duckietown Software repository with:
 
@@ -67,7 +67,7 @@ if the output of `make fuses` is at the end like
 
     avrdude done.  Thank you.
 
-the connection to the MC works and the fuses could be written. The fuses are some low lowlevel settings, which just have to be set once. If this succeeded, jump the next step.
+the connection to the microcontroller works and the fuses could be written. The fuses are some low lowlevel settings, which just have to be set once. If this succeeded, jump the next step.
 
 
 If there is the message "make: warning: Clock skew detected. Your build may be incomplete." or the make process is not stopping and many debugging messages are showed, try the following:
@@ -82,7 +82,7 @@ Next up, remove all temporary files, so everything has to be compiled freshly by
 
     duckiebot $ make clean
 
-Compile the programm and download it to the MC by running:
+Compile the programm and download it to the microcontroller by running:
 
     duckiebot $ make
 
@@ -123,7 +123,7 @@ the output should look like:
 
     avrdude done.  Thank you.
 
-With that, the MC should work. To change the MC programm, just edit the files, e.g with vim. With `make` you can compile and download the programm to the MC again.
+With that, the microcontroller should work. To change the microcontroller programm, just edit the files, e.g with vim. With `make` you can compile and download the programm to the microcontroller again.
 
 In the end, make sure to delete the Software repository to free up the space again. This is done by running:
 

--- a/book/opmanual_duckiebot/atoms_18_setup_troubleshooting/10_boot_and_recovery.md
+++ b/book/opmanual_duckiebot/atoms_18_setup_troubleshooting/10_boot_and_recovery.md
@@ -29,3 +29,101 @@ Resolution: An older version of the SD card image had the docker container `cjim
     duckiebot $ docker rm $(docker stop $(docker ps -a -q --filter ancestor=cjimti/iotwifi --format="{{.ID}}"))
     duckiebot $ sudo systemctl unmask wpa_supplicant
     duckiebot $ sudo systemctl restart networking.service
+
+## The LEDs light up in a variety of colors when i plug in the battery.
+
+Symptom: The LEDs light up in a variety of colors when i plug in the battery.
+
+Resolution: The LEDs of the Duckiebot should light up in white as soon as you power the Duckiebot. If the LEDs turn on and shine in any different color than white, probably the code on the microcontroller is corrupted. You can reflash it using the following procedure:
+
+`ssh` into your robot and clone the Duckietown Software repository with:
+
+    duckiebot $ git clone https://github.com/duckietown/Software.git ~/Software
+
+install avrdude and gcc with:
+
+    duckiebot $ sudo apt-get update
+    duckiebot $ sudo apt-get install bison autoconf flex
+    duckiebot $ sudo apt-get install gcc-avr binutils-avr gdb-avr avr-libc avrdude
+    duckiebot $ sudo apt-get install build-essential
+
+Copy the avrdude config file with:
+
+    duckiebot $ cd ~/Software/hardware/software
+    duckiebot $ sudo cp avrdude.conf /etc/avrdude.conf
+
+Test avrdude and set fuses with:
+
+    duckiebot $ cd ~/Software/hardware/software
+    duckiebot $ make fuses
+
+if the output of `make fuses` is at the end like
+
+    avrdude: verifying …
+    avrdude: 1 bytes of efuse verified
+
+    avrdude: safemode: Fuses OK (E:FF, H:DF, L:E2)
+
+
+    avrdude done.  Thank you.
+
+the connection to the MC works and the fuses could be written. The fuses are some low lowlevel settings, which just have to be set once for each microcontroller.  If this succeeded, jump the next step.
+
+If there is the message "make: warning: Clock skew detected. Your build may be incomplete." or the make process is not stopping and many debugging messages are showed, try the following:
+Press <kbd>Ctrl</kbd>-<kbd>C</kbd> to stop the current command. Then run:
+
+    duckiebot $ find -exec touch \{\} \;
+
+This ensures that the modification time of all files is set to the current time. Make decides, which files have to be compiled by comparing the source file time with the executable file time. If the executable file time lies in the future regarding the current system time, not all modified files are compiled. This could happen when the clock of the Raspberry Pi is not set correctly and the file timestamps of, e.g., a github pull are used.
+
+Next up, remove all temporary files, so everything has to be compiled freshly by running:  
+
+    duckiebot $ make clean
+
+Compile the programm and download it to the MC by running:
+
+    duckiebot $ make
+
+the output should look like:
+    ...
+
+    Errors: none
+    -------- end --------
+
+    sudo avrdude -p attiny861 -c linuxgpio -P  -q -U flash:w:main.hex
+
+    avrdude: AVR device initialized and ready to accept instructions
+
+    Reading | ################################################## | 100% 0.00s
+
+    avrdude: Device signature = 0x1e930d (probably t861)
+    avrdude: NOTE: "flash" memory has been specified, an erase cycle will be performed
+         To disable this feature, specify the -D option.
+    avrdude: erasing chip
+    avrdude: reading input file "main.hex"
+    avrdude: input file main.hex auto detected as Intel Hex
+    avrdude: writing flash (2220 bytes):
+
+    Writing | ################################################## | 100% 0.75s
+
+    avrdude: 2220 bytes of flash written
+    avrdude: verifying flash memory against main.hex:
+    avrdude: load data flash data from input file main.hex:
+    avrdude: input file main.hex auto detected as Intel Hex
+    avrdude: input file main.hex contains 2220 bytes
+    avrdude: reading on-chip flash data:
+
+    Reading | ################################################## | 100% 0.58s
+
+    avrdude: verifying ...
+    avrdude: 2220 bytes of flash verified
+
+    avrdude: safemode: Fuses OK (E:FF, H:DF, L:E2)
+
+    avrdude done.  Thank you.
+
+With that, the MC should work. To change the MC programm, just edit the files, e.g with vim. With $ make you can compile and download the programm to the MC again.
+
+In the end, make sure to delete the Software repository to free up the space again. This is done by running:
+
+    duckiebot $ rm -rf ~/Software

--- a/book/opmanual_duckiebot/atoms_18_setup_troubleshooting/10_boot_and_recovery.md
+++ b/book/opmanual_duckiebot/atoms_18_setup_troubleshooting/10_boot_and_recovery.md
@@ -122,7 +122,7 @@ the output should look like:
 
     avrdude done.  Thank you.
 
-With that, the MC should work. To change the MC programm, just edit the files, e.g with vim. With $ make you can compile and download the programm to the MC again.
+With that, the MC should work. To change the MC programm, just edit the files, e.g with vim. With `&#36; make` you can compile and download the programm to the MC again.
 
 In the end, make sure to delete the Software repository to free up the space again. This is done by running:
 


### PR DESCRIPTION
also added: 
-outdated lines saying DT18 was still the most current version
-description of the new boot process (https://github.com/duckietown/duckietown-shell-commands/pull/118)