### PR TITLE
Update 0_5_0_laptop.md

### DIFF
--- a/book/opmanual_duckiebot/atoms_17_operation_manual_duckiebot/0_5_0_laptop.md
+++ b/book/opmanual_duckiebot/atoms_17_operation_manual_duckiebot/0_5_0_laptop.md
@@ -55,7 +55,7 @@ See: For instructions, see for example [this online tutorial][tutorial].
 
 Installs pip, git, git-lfs, curl, wget:
 
-    laptop $ sudo apt install -y python-pip git git-lfs curl wget
+    laptop $ sudo apt install -y python3-pip git git-lfs curl wget
 
 ### Docker {#laptop-setup-ubuntu-18-docker}
 


### PR DESCRIPTION
Believe that installing python-pip might cause dts linking to python 2.7 and failing. Installed python3-pip instead and dts works. 