### PR TITLE
Demos commands update and cleanup

### DIFF
--- a/book/opmanual_duckiebot/atoms_17_operation_manual_duckiebot/2_2_2_camera_calibration.md
+++ b/book/opmanual_duckiebot/atoms_17_operation_manual_duckiebot/2_2_2_camera_calibration.md
@@ -47,6 +47,10 @@ The procedure is basically a wrapper around the [ROS camera calibration tool](ht
 
 ### Publish raw imagery
 
+First, check if your `duckiebot-interface` container is running. If it is not, start it with
+
+    laptop $ docker -H ![DUCKIEBOT_NAME].local run --name duckiebot-interface -v /data:/data --privileged --network=host -dit --restart unless-stopped duckietown/dt-duckiebot-interface:daffy-amd64
+
 We want uncompressed imagery for this which is not streamed by default from the duckiebot. To get it you can run the "camera" demo:
 
     laptop $ dts duckiebot demo --demo_name camera --duckiebot_name ![DUCKIEBOT_NAME] --package_name pi_camera --image duckietown/dt-core:daffy

--- a/book/opmanual_duckiebot/atoms_17_operation_manual_duckiebot/2_2_2_camera_calibration.md
+++ b/book/opmanual_duckiebot/atoms_17_operation_manual_duckiebot/2_2_2_camera_calibration.md
@@ -49,7 +49,7 @@ The procedure is basically a wrapper around the [ROS camera calibration tool](ht
 
 First, check if your `duckiebot-interface` container is running. If it is not, start it with
 
-    laptop $ docker -H ![DUCKIEBOT_NAME].local run --name duckiebot-interface -v /data:/data --privileged --network=host -dit --restart unless-stopped duckietown/dt-duckiebot-interface:daffy-amd64
+    laptop $ docker -H ![DUCKIEBOT_NAME].local run --name duckiebot-interface -v /data:/data --privileged --network=host -dit --restart unless-stopped duckietown/dt-duckiebot-interface:daffy
 
 We want uncompressed imagery for this which is not streamed by default from the duckiebot. To get it you can run the "camera" demo:
 

--- a/book/opmanual_duckiebot/atoms_30_demos/00_skeleton/02_running_demos.md
+++ b/book/opmanual_duckiebot/atoms_30_demos/00_skeleton/02_running_demos.md
@@ -4,7 +4,7 @@ This page describes the basic procedure for running demos. Some demos have speci
 
 <div class='requirements' markdown='1'>
 
-Requires: A Duckiebot in `DB18` configuration that is [initalized](#setup-duckiebot) has [camera](#camera-calib) and [wheels](#wheel-calibration) calibrated
+Requires: A Duckiebot in `DB18` configuration that is [initalized](#setup-duckiebot)
 
 Requires: Laptop configured, according to [](#laptop-setup).
 
@@ -13,23 +13,22 @@ Requires: Other requirements are demo specific, see the specific pages
 </div>
 
 ## Start demos
-In the [Duckietown software repo](https://github.com/duckietown/Software), the launch files are currently separated in two different packages (folders).
+In the [Duckietown software repo](https://github.com/duckietown/Software), there are two main types of launch files: node-specific (nuclear) ones, and demo launch files. A node launch file handles only a single node and its parameters. A demo launch file combines multiple of node launch files and adds the neccessary connections in order to stage demos that use dozens of nodes.
 
-**The [`duckietown` package](https://github.com/duckietown/Software/tree/master19/catkin_ws/src/00-infrastructure/duckietown/launch)** has launch files which are constructed "additively" through `include` tags. This is the default package used to run launch files. Any launch file in this folder can be run through the [duckietown shell](#laptop-setup-ubuntu-18-shell) with the following command:
+The launch procedure for both types is very similar. The generic command is:
 
-    laptop $ dts duckiebot demo --duckiebot_name ![DUCKIEBOT_NAME] --demo_name ![DEMO_NAME] --image duckietown/dt-core:daffy
+    laptop $ dts duckiebot demo --duckiebot_name ![DUCKIEBOT_NAME] --demo_name ![DEMO_NAME] --package_name ![PACKAGE_NAME] --image duckietown/![IMAGE]:daffy
+    
+This command will start the `DEMO_NAME.launch` launch file in the `PACKAGE_NAME` package from the `duckietown/![IMAGE]:daffy` Docker image on the `DUCKIEBOT_NAME` duckiebot.
 
-where `![DEMO_NAME]` is the part before the `.launch` of a `![DEMO_NAME].launch` file.
+Note: Currently `daffy` is the development branch and the `dts` commands work by default with the `master19` version. That is why you should __always__ specify the image with the `daffy` tag!
 
-**The [`duckietown_demos` package](https://github.com/duckietown/Software/tree/master19/catkin_ws/src/70-convenience-packages/duckietown_demos/launch)** contains generally more complicated assemblies of capabilities that are composed into actions. These launch files are constructed "destructively" where each one includes the [`master.launch`](https://github.com/duckietown/Software/blob/master19/catkin_ws/src/70-convenience-packages/duckietown_demos/launch/master.launch) which contains `include` blocks for every node that exists in the Duckietown Software repository. These include blocks are activated and de-activated through a series of `args` that act as switches which are structured hierarchically at the top of the `master.launch` file. To run any launch file in this package through the shell (and actually any launch file in any package) you can additionally specify the `package_name` as an argument:
+You can find the specific command for each demo in the corresponding part of the book. 
 
-    laptop $ dts duckiebot demo --duckiebot_name ![DUCKIEBOT_NAME] --demo_name ![DEMO_NAME] --package_name duckietown_demos
-
-where, similarly to above,  `![DEMO_NAME]` is the part before the `.launch` of a `![DEMO_NAME].launch` file.
 
 ## Debug options
 You can open a terminal in the container running the demo you want by appending the option `--debug` to the command. An example is:
 
-    laptop $ dts duckiebot demo --duckiebot_name ![DUCKIEBOT_NAME] --demo_name ![DEMO_NAME] --package_name duckietown_demos --debug
+    laptop $ dts duckiebot demo --duckiebot_name ![DUCKIEBOT_NAME] --demo_name ![DEMO_NAME] --package_name ![PACKAGE_NAME] --image duckietown/![IMAGE]:daffy --debug
 
-This enables you to access to the `ROS` debug informations of the nodes that are launched.
+This enables you to access to the `ROS` debug informations of the nodes that are launched. This is the same output that you can see in the `logs` window of the particular container on Portainer.

--- a/book/opmanual_duckiebot/atoms_30_demos/10_calibration_demos/11_camera_calibration.md
+++ b/book/opmanual_duckiebot/atoms_30_demos/10_calibration_demos/11_camera_calibration.md
@@ -1,4 +1,4 @@
-# Camera Calibration Verification Test {#demo-camcaltest status=ready}
+# Camera Calibration Verification Test {#demo-camcaltest status=draft}
 
 This document provides instructions for testing the camera calibration.
 

--- a/book/opmanual_duckiebot/atoms_30_demos/10_calibration_demos/11_camera_calibration.md
+++ b/book/opmanual_duckiebot/atoms_30_demos/10_calibration_demos/11_camera_calibration.md
@@ -1,4 +1,4 @@
-# Camera Calibration Verification Test {#demo-camcaltest status=draft}
+# Camera Calibration Verification Test {#demo-camcaltest status=beta}
 
 This document provides instructions for testing the camera calibration.
 

--- a/book/opmanual_duckiebot/atoms_30_demos/10_calibration_demos/15_system_identification.md
+++ b/book/opmanual_duckiebot/atoms_30_demos/10_calibration_demos/15_system_identification.md
@@ -1,4 +1,4 @@
-# System Identification {#demo-sysidII status=ready}
+# System Identification {#demo-sysidII status=beta}
 
 This document provides instructions for performing an offline system identification procedure. The identification procedure is completed in three stages.
 

--- a/book/opmanual_duckiebot/atoms_30_demos/20_basic_operations/20_lane_following.md
+++ b/book/opmanual_duckiebot/atoms_30_demos/20_basic_operations/20_lane_following.md
@@ -79,7 +79,7 @@ If you have a joystick you can skip this next command, otherwise we need to run 
 
 Start the lane following. The Duckiebot should drive autonomously in the lane. Intersections and red lines are neglected and the Duckiebot will drive across them like it is a normal lane. You can regain control of the bot at any moment by stopping the lane following and using the (virtual) joystick. Resuming the demo is as easy as pressing the corresponding start button.
 
-Enjoy the demo!
+Et voilà! We are ready to drive around autonomously.
 
 ### Step 3: Visualize the detected line segments (optional)
 
@@ -100,9 +100,6 @@ Now select the `/![DUCKIEBOT_NAME]/line_detector_node/image_with_lines` in `rqt_
     </figcaption>
     <dtvideo src='vimeo:334931437'/>
 </div>
-
-Et voilà! We are ready to drive around autonomously.
-
 
 ### Step 4: Extras
 

--- a/book/opmanual_duckiebot/atoms_30_demos/20_basic_operations/20_lane_following.md
+++ b/book/opmanual_duckiebot/atoms_30_demos/20_basic_operations/20_lane_following.md
@@ -46,42 +46,54 @@ Assumption about Duckietown:
 
 ## Demo instructions {#demo-lane-following-run}
 
-### Step 1
+### Step 1: Start the demo containers
 
-Run the demo:
+Running this demo requires almost all of the main Duckietown ROS nodes to be up and running. As these span 3 Docker images (`dt-duckiebot-interface`, `dt-car-interface`, and `dt-core`, we will need to start all of them.
+
+First, start all the drivers in `dt-duckiebot-interface`:
+
+    laptop $ dts duckiebot demo --demo_name all_drivers --duckiebot_name ![DUCKIEBOT_NAME] --package_name duckiebot_interface --image duckietown/dt-duckiebot-interface:daffy
+    
+Then, start the glue nodes that handle the joystick mapping and the kinematics:
+
+    laptop $ dts duckiebot demo --demo_name all --duckiebot_name ![DUCKIEBOT_NAME] --package_name car_interface --image duckietown/dt-car-interface:daffy
+
+Finally, we are ready to start the high-level pipeline for lane following:
 
     laptop $ dts duckiebot demo --demo_name lane_following --duckiebot_name ![DUCKIEBOT_NAME] --package_name duckietown_demos --image duckietown/dt-core:daffy
 
-This will start the `demo_lane_following` container. You have to wait a while for everything to start working.
+You have to wait a while for everything to start working. While you wait, you can check in Portainer if all the containers started successfully and in their logs for any possible issues.
 
-### Step 2
+### Step 2: Make your Duckiebot drive autonomously!
 
-Now we will verify that `lane_filter_node` is working. On your laptop run `start_gui_tools`.
+If you have a joystick you can skip this next command, otherwise we need to run the keyboard controller:
 
-    laptop $ dts start_gui_tools ![hostname]
+    laptop $ dts duckiebot keyboard_control ![DUCKIEBOT_NAME]
 
-This will enter you into a container on your laptop that can talk to the ROS on the robot. To verify this do:
 
-    laptop-container $ rostopic list
+|        Controls      |  Joystick  |     Keyboard     |
+|----------------------|:----------:|:----------------:|
+| Start Lane Following |   __R1__   |   <kbd>a</kbd>   |
+| Stop Lane Following  |   __L1__   |   <kbd>s</kbd>   |
 
-and you should see all of the rostopics listed there. If you see an output like "Cannot communicate with ROS_MASTER" that's a problem.
 
-Next run:
+Start the lane following. The Duckiebot should drive autonomously in the lane. Intersections and red lines are neglected and the Duckiebot will drive across them like it is a normal lane. You can regain control of the bot at any moment by stopping the lane following and using the (virtual) joystick. Resuming the demo is as easy as pressing the corresponding start button.
 
-    laptop-container $ rqt_image_view
+Enjoy the demo!
 
-Select the `/![hostname]/camera_node/image/compressed` topic from the drop down in the popup window and you should see the video stream.
+### Step 3: Visualize the detected line segments (optional)
 
-### Step 3
+This step is not neccessary but provides a nice visualization of the line segments that the Duckiebot detects. 
 
-Now we need to make `lane_filter_node` publish all the image topics.
+For that, we need to make `lane_filter_node` publish all the image topics.
+
 We can do this by setting the ROS parameter `verbose` to `true`:
 
-    laptop-container $ rosparam set /![hostname]/line_detector_node/verbose true
+    container $ rosparam set /![DUCKIEBOT_NAME]/line_detector_node/verbose true
 
 so that `line_detector_node` will publish the image_with_lines.
 
-Now select the `/![hostname]/line_detector_node/image_with_lines` in `rqt_image_view` and you should see something like this:
+Now select the `/![DUCKIEBOT_NAME]/line_detector_node/image_with_lines` in `rqt_image_view` and you should see something like this:
 
 <div figure-id="fig:line_detector">
     <figcaption>Outcome of the line detector node.
@@ -92,19 +104,13 @@ Now select the `/![hostname]/line_detector_node/image_with_lines` in `rqt_image_
 Et voilà! We are ready to drive around autonomously.
 
 
-### Step 4
+### Step 4: Extras
 
-If you have a joystick you can skip this next command, otherwise we need to run the keyboard controller:
+Here are some additional things you can try:
 
-    laptop $ dts duckiebot keyboard_control ![hostname]
+* Get a [remote stream](#read-camera-data) of your Duckiebot.
+* Try to change some of the ROS parameters to see how your Duckiebot's behavior will change. 
 
-|        Controls      |  Joystick  |  Keyboard |
-|----------------------|:----------:|:---------:|
-| Start Lane Following |   __R1__   |   __a__   |
-| Stop Lane Following  |   __L1__   |   __s__   |
-
-
-Start the lane following. The Duckiebot should drive autonomously in the lane. Intersections and red lines are neglected and the Duckiebot will drive across them like it is a normal lane. Enjoy the demo.
 
 ## Troubleshooting {#demo-lane-following-troubleshooting}
 
@@ -131,8 +137,8 @@ Solution (advanced):
 
 Set alternative controller gains. While running the demo on the Duckiebot use the following to set the gains to the alternative values:
 
-    laptop $ rosparam set /![hostname]/lane_controller_node/k_d -45
+    laptop $ rosparam set /![DUCKIEBOT_NAME]/lane_controller_node/k_d -45
 
-    laptop $ rosparam set /![hostname]/lane_controller_node/k_theta -11
+    laptop $ rosparam set /![DUCKIEBOT_NAME]/lane_controller_node/k_theta -11
 
-Those changes are only active while running the demo and need to be repeated at every start of the demo if needed. If this improved the performance of your Duckiebot, you should think about permenantly change the default values in your catkin_ws.
+Those changes are only active while running the demo and need to be repeated at every start of the demo if needed. If this improved the performance of your Duckiebot, you should think about permenantly change the default values in your `catkin_ws`.

--- a/book/opmanual_duckiebot/atoms_30_demos/30_advanced_demos/11_indefinite_navigation.md
+++ b/book/opmanual_duckiebot/atoms_30_demos/30_advanced_demos/11_indefinite_navigation.md
@@ -8,8 +8,6 @@ Requires: [Wheel calibration](#wheel-calibration) completed.
 
 Requires: [Camera calibration](#camera-calib) completed.
 
-Requires: [Lane following](#demo-lane-following) demo has been successfully launched.
-
 Requires: Fully set up Duckietown.
 
 Results: One or more Duckiebot safely navigating in Duckietown.
@@ -105,6 +103,7 @@ Now select the `/![DUCKIEBOT_NAME]/line_detector_node/image_with_lines` in `rqt_
 Here are some additional things you can try:
 
 * Get a [remote stream](#read-camera-data) of your Duckiebot.
+* You can visualize the detected line segments the same way as for the [lane following demo](#demo-lane-following)
 * Try to change some of the ROS parameters to see how your Duckiebot's behavior will change. 
 
 ## Troubleshooting

--- a/book/opmanual_duckiebot/atoms_30_demos/30_advanced_demos/11_indefinite_navigation.md
+++ b/book/opmanual_duckiebot/atoms_30_demos/30_advanced_demos/11_indefinite_navigation.md
@@ -41,27 +41,71 @@ One (or possibly more) Duckiebot in configuration [DB18](#duckiebot-configuratio
 
 ## Pre-flight checklist {#demo-indefinite-navigation-pre-flight}
 
-Check: Sufficient battery charge of the Duckiebot.
-
-Check: Duckiebot is properly calibrated.
+Check that every Duckiebot has sufficient battery charge and that they are all properly calibrated.
 
 ## Demo instructions {#demo-indefinite-navigation-run}
 
-Follow these steps to run the indefinite navigation demo on your Duckiebot:
+### Step 1: Start the demo containers
 
-**Step 1**: Power on your bot and wait for the `duckiebot-interface` to initialize (the LEDs go off).
+Running this demo requires almost all of the main Duckietown ROS nodes to be up and running. As these span 3 Docker images (`dt-duckiebot-interface`, `dt-car-interface`, and `dt-core`, we will need to start all of them.
 
-**Step 2**: Launch the demo by running:
+First, start all the drivers in `dt-duckiebot-interface`:
 
-    laptop $ dts duckiebot demo --demo_name indefinite_navigation --duckiebot_name ![DUCKIEBOT_NAME] --package_name duckietown_demos
+    laptop $ dts duckiebot demo --demo_name all_drivers --duckiebot_name ![DUCKIEBOT_NAME] --package_name duckiebot_interface --image duckietown/dt-duckiebot-interface:daffy
+    
+Then, start the glue nodes that handle the joystick mapping and the kinematics:
 
-Note: Many nodes need to be launched, so it will take quite some time.
+    laptop $ dts duckiebot demo --demo_name all --duckiebot_name ![DUCKIEBOT_NAME] --package_name car_interface --image duckietown/dt-car-interface:daffy
 
-**Step 3**: With the joystick or In a separate terminal, start the joystick GUI:
+Finally, we are ready to start the high-level pipeline for indefinite navigation:
 
-    laptop $ dts duckiebot keyboard_control ![hostname]
+    laptop $ dts duckiebot demo --demo_name indefinite_navigation --duckiebot_name ![DUCKIEBOT_NAME] --package_name duckietown_demos --image duckietown/dt-core:daffy
 
-and use the instructions to toggle between autonomous navigation and joystick control modes.
+You have to wait a while for everything to start working. While you wait, you can check in Portainer if all the containers started successfully and in their logs for any possible issues.
+
+### Step 2: Make your Duckiebot drive autonomously!
+
+If you have a joystick you can skip this next command, otherwise we need to run the keyboard controller:
+
+    laptop $ dts duckiebot keyboard_control ![DUCKIEBOT_NAME]
+
+
+|        Controls      |  Joystick  |     Keyboard     |
+|----------------------|:----------:|:----------------:|
+| Start Lane Following |   __R1__   |   <kbd>a</kbd>   |
+| Stop Lane Following  |   __L1__   |   <kbd>s</kbd>   |
+
+
+Start the lane following. The Duckiebot should drive autonomously in the lane. Intersections and red lines are neglected and the Duckiebot will drive across them like it is a normal lane. You can regain control of the bot at any moment by stopping the lane following and using the (virtual) joystick. Resuming the demo is as easy as pressing the corresponding start button.
+
+Et voilà! We are ready to drive around autonomously.
+
+### Step 3: Visualize the detected line segments (optional)
+
+This step is not neccessary but provides a nice visualization of the line segments that the Duckiebot detects. 
+
+For that, we need to make `lane_filter_node` publish all the image topics.
+
+We can do this by setting the ROS parameter `verbose` to `true`:
+
+    container $ rosparam set /![DUCKIEBOT_NAME]/line_detector_node/verbose true
+
+so that `line_detector_node` will publish the image_with_lines.
+
+Now select the `/![DUCKIEBOT_NAME]/line_detector_node/image_with_lines` in `rqt_image_view` and you should see something like this:
+
+<div figure-id="fig:line_detector">
+    <figcaption>Outcome of the line detector node.
+    </figcaption>
+    <dtvideo src='vimeo:334931437'/>
+</div>
+
+### Step 4: Extras
+
+Here are some additional things you can try:
+
+* Get a [remote stream](#read-camera-data) of your Duckiebot.
+* Try to change some of the ROS parameters to see how your Duckiebot's behavior will change. 
 
 ## Troubleshooting
 

--- a/book/opmanual_duckiebot/atoms_30_demos/30_advanced_demos/11_indefinite_navigation.md
+++ b/book/opmanual_duckiebot/atoms_30_demos/30_advanced_demos/11_indefinite_navigation.md
@@ -32,7 +32,7 @@ TODO: add a different video with an up to specification Duckietown.
 
 ## Duckietown setup notes {#demo-indefinite-navigation-duckietown-setup}
 
-To run this demo, you can setup a quite complex Duckietown. The demo supports normal road tiles, intersections and traffic lights. Make sure that your Duckietown complies with the appereance specifications presented in [the Duckietown specs](+opmanual_duckietown#dt-ops-appearance-specifications). In particular correct street signaling is key to success of intersections handling.
+To run this demo, you can setup a quite complex Duckietown. The demo supports normal road tiles, intersections and traffic lights. That makes it a a level more difficult than the [lane following demo](#demo-lane-following). Make sure that your Duckietown complies with the appereance specifications presented in [the Duckietown specs](+opmanual_duckietown#dt-ops-appearance-specifications). In particular correct street signaling is key to success of intersections handling.
 
 
 ## Duckiebot setup notes {#demo-indefinite-navigation-duckiebot-setup}

--- a/book/opmanual_duckiebot/atoms_30_demos/30_advanced_demos/11_indefinite_navigation.md
+++ b/book/opmanual_duckiebot/atoms_30_demos/30_advanced_demos/11_indefinite_navigation.md
@@ -78,26 +78,6 @@ Start the lane following. The Duckiebot should drive autonomously in the lane. I
 
 Et voilà! We are ready to drive around autonomously.
 
-### Step 3: Visualize the detected line segments (optional)
-
-This step is not neccessary but provides a nice visualization of the line segments that the Duckiebot detects. 
-
-For that, we need to make `lane_filter_node` publish all the image topics.
-
-We can do this by setting the ROS parameter `verbose` to `true`:
-
-    container $ rosparam set /![DUCKIEBOT_NAME]/line_detector_node/verbose true
-
-so that `line_detector_node` will publish the image_with_lines.
-
-Now select the `/![DUCKIEBOT_NAME]/line_detector_node/image_with_lines` in `rqt_image_view` and you should see something like this:
-
-<div figure-id="fig:line_detector">
-    <figcaption>Outcome of the line detector node.
-    </figcaption>
-    <dtvideo src='vimeo:334931437'/>
-</div>
-
 ### Step 4: Extras
 
 Here are some additional things you can try:

--- a/book/opmanual_duckiebot/atoms_30_demos/30_advanced_demos/39_megacity.md
+++ b/book/opmanual_duckiebot/atoms_30_demos/30_advanced_demos/39_megacity.md
@@ -1,4 +1,4 @@
-# Megacity {#demo-megacity status=ready}
+# Megacity {#demo-megacity status=beta}
 
 This is the description of the great and marvelous megacity demo.
 

--- a/book/opmanual_duckiebot/atoms_30_demos/50_development/992_AMOD18_cSLAM.md
+++ b/book/opmanual_duckiebot/atoms_30_demos/50_development/992_AMOD18_cSLAM.md
@@ -1,4 +1,4 @@
-# AMOD18 cSLAM {#demo-cslam status=ready}
+# AMOD18 cSLAM {#demo-cslam status=beta}
 
 <div figure-id="fig:cslam_logo">
      <img src="cSLAM_images/cSLAM_logo.png" style='width: 20em'/>

--- a/book/opmanual_duckiebot/atoms_30_demos/50_development/997_AMOD18_Intersection_Navigation.md
+++ b/book/opmanual_duckiebot/atoms_30_demos/50_development/997_AMOD18_Intersection_Navigation.md
@@ -1,4 +1,4 @@
-# AMOD18 Project Unicorn {#demo-projectunicorn status=ready}
+# AMOD18 Project Unicorn {#demo-projectunicorn status=beta}
 
 **Project Unicorn** is a project for AMOD (Autonomous Mobility On Demand) course from ETH Zürich that focuses on the intersection navigation for duckiebots in Duckietown.
 

--- a/book/opmanual_duckiebot/atoms_30_demos/50_development/998_AMOD18_VisualOdometry.md
+++ b/book/opmanual_duckiebot/atoms_30_demos/50_development/998_AMOD18_VisualOdometry.md
@@ -1,4 +1,4 @@
-# AMOD18 Visual Odometry {#demo-visualodometry status=ready}
+# AMOD18 Visual Odometry {#demo-visualodometry status=beta}
 
 This is the report of the AMOD18 Visual Odometry group. In the first section we present how to run the demo, while the second section is dedicated on a more complete report of our work.
 

--- a/book/opmanual_duckiebot/atoms_90_references/00_part_demos_trouble.md
+++ b/book/opmanual_duckiebot/atoms_90_references/00_part_demos_trouble.md
@@ -1,4 +1,4 @@
-# References {#part:demos-references status=ready}
+# References {#part:demos-references status=beta}
 
 Here is a list of the citated texts.
 


### PR DESCRIPTION
- Demos were not updated to run under `daffy`. Now they are.
- Demos that were not tested/updated to run under `daffy` yet were put in `beta` state, effectively hiding them from the public book.