### PR TITLE
Added OS X workaround

### DIFF
--- a/book/opmanual_duckiebot/atoms_17_operation_manual_duckiebot/0_5_0_laptop.md
+++ b/book/opmanual_duckiebot/atoms_17_operation_manual_duckiebot/0_5_0_laptop.md
@@ -184,7 +184,7 @@ Follow [these instructions](https://docs.docker.com/docker-for-mac/install/)
 ### Duckietown Shell {#laptop-setup-mac-shell}
 
 Follow [these instructions](https://github.com/duckietown/duckietown-shell)
-
+Note: On OS X if you get a `Could not load commands` error when you run `dts` for the first time. Try deleting `~/.dt-shell/commands-multi/daffy/challenges/installed.flag` and running `dts` again.
 
 
 ## Setup for Ubuntu 16.04 {#laptop-setup-ubuntu-16}


### PR DESCRIPTION
For the unsupported OS X version of dts to run, you need to remove that installed flag, otherwise it will not download the commands properly. 

I'm not sure if it is best to put it here as a note, or in the git documentation linked to in that same section, but it should be visible somewhere.